### PR TITLE
Fix postLabels

### DIFF
--- a/src/functions/common/functions_system.php
+++ b/src/functions/common/functions_system.php
@@ -166,14 +166,16 @@ function get_label($label, $lang = null)
   }
 
   if ($label != null && $lang != null) {
-    if (isset(NF::$site->labels[$base64label][$lang])) {
-      return NF::$site->labels[$base64label][$lang];
+    if (isset(NF::$site->labels[$base64label])) {
+      return NF::$site->labels[$base64label][$lang] ?? $label;
     } else {
       try {
         NF::$capi->post('foundation/labels', ['json' => [
           'label' => $base64label
         ]]);
-      } catch (Exception $e) {} finally {
+      } catch (Exception $e) {
+        // No action
+      } finally {
         NF::$cache->delete('labels');
         NF::$site->loadLabels();
       }

--- a/tests/mocks/Cache.php
+++ b/tests/mocks/Cache.php
@@ -20,4 +20,10 @@ class MockCache {
   public function clear () {
     $this->items = [];
   }
+
+  public function delete($key) {
+    if(isset($this->items[$key]))
+      unset($this->items[$key]);
+    return $this->items;
+  }
 }


### PR DESCRIPTION
Our previous attempt at fixing the postLabels problem has been insufficient.
This patch should solve this problem once and for all.

Here is a graph of the old behaviour on a customer site, then with the patch applied, while the site is under constant load. 
Then we revert to the bugged code and verify the calls to postLabels returns.
Then we reapply the fix and the calls are once again gone.
![image](https://user-images.githubusercontent.com/1438488/86258823-8998ea80-bbbb-11ea-9629-5528bc8b7d50.png)

The issue was that we didnt check for the presence of the label key, but we checked for the presence of a valid translation of the label key in the wanted language. However, we only store and send explicit translations that are different than their "raw" base label. The null/non-existent key/language combination when asking for a label in a language that had not been translate would force the sdk to try to create the label.

This fixes this by instead checking for label/lang combo, only checking for the existence of the label, then fallbacking to label key if language value is not present.

This passes the testsuite and looks like it should not break standard behaviour on test sites and the customer site where the fix has been applied.